### PR TITLE
feat: add huggingface tokenizer for accurate token counting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ REDIS_URL=redis://localhost:6379
 # App Configuration
 NODE_ENV=development
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Token Counting
+HUGGING_FACE_API_KEY=your_hugging_face_api_key

--- a/backend/huggingface/hf_tokenizer.py
+++ b/backend/huggingface/hf_tokenizer.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from transformers import AutoTokenizer
+
+def load_tokenizer_from_hf(
+    primary_model: str = "meta-llama/Llama-3.1-8B", # gated
+    fallback_model: str = "meta-llama/Llama-2-7b" # public
+) -> AutoTokenizer | None:
+    """
+    This is used for encoding, decoding, token counting of text chunks
+
+    # https://huggingface.co/meta-llama/Llama-3.1-8B
+    """
+    import os
+    from dotenv import load_dotenv
+    from transformers import AutoTokenizer
+    from huggingface_hub import login
+    from huggingface_hub.utils import (
+        GatedRepoError,
+        RepositoryNotFoundError
+    )
+    load_dotenv()
+    HF_TOKEN = os.getenv('HUGGING_FACE_API_KEY', None)
+    if HF_TOKEN is None:
+        raise ValueError("HUGGING_FACE_TOKEN not found in environment variables")
+
+    try:
+        login(token=HF_TOKEN)
+    except Exception as e:
+        print(f"Error logging in to Hugging Face: {e}")
+        return None
+
+    for model_name in [primary_model, fallback_model]:
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            print(f"Successfully loaded tokenizer '{model_name}'.")
+            return tokenizer
+        except GatedRepoError as e:
+            print(f"GatedRepoError: {e}")
+        except RepositoryNotFoundError as e:
+            print(f"RepositoryNotFoundError: {e}")
+        except Exception as e:
+            print(f"Exception: {e}")
+
+    print("Failed to load tokenizer for primary and fallback models")
+    return None
+
+
+def count_tokens(text: str, debug: bool = False) -> int | None:
+    """
+    Count the number of tokens in the given text using the provided tokenizer.
+    """
+    tokenizer = load_tokenizer_from_hf()
+    if tokenizer is None:
+        raise ValueError("Tokenizer not found")
+    encoded = tokenizer.encode(text)
+    num_tokens = len(encoded)
+    if type(num_tokens) != int:
+        raise TypeError("Number of tokens is not an integer")
+    if debug:
+        print(f'{num_tokens = }')
+    return num_tokens
+
+
+if __name__ == "__main__":
+    text = "The quick brown fox jumps over the lazy dog."
+    num_tokens = count_tokens(text, debug=True)


### PR DESCRIPTION
This pull request introduces a new feature for token counting using the Hugging Face API. The changes include adding a new environment variable for the API key, creating a new Python script to handle tokenization, and ensuring proper error handling.

Key changes:

Environment configuration:
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR24-R26): Added `HUGGING_FACE_API_KEY` for token counting.

Token counting functionality:
* [`backend/huggingface/hf_tokenizer.py`](diffhunk://#diff-7e0561c59280d97bc97a0ef7802a8d3b29a3c556dbe7bdf2d32c83a7df6e01b1R1-R66): Created a new script to load tokenizers from Hugging Face, count tokens in text, and handle various errors during the process.

Inside `backend/cerebras/text_to_summary.py` (PR not in yet) 
we can import token counting like so:
```python
from ..huggingface.hf_tokenizer import load_tokenizer_from_hf, count_tokens
```

The tokenizer if loaded can encode and decode text / plenty of features while the count_tokens will return an int value of the number of tokens in text fed to the function. Partially addresses #19 but not tested on non-English languages