### PR TITLE
docs: document compatible Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ To get a local copy up and running, follow these steps.
   ```sh
   npm install -g pnpm
   ```
-* Python (3.8 or later)
+* Python (>=3.8,<3.13)
 
 ### Installation
 


### PR DESCRIPTION
Until <https://github.com/explosion/cython-blis/issues/118> is completed, Python 3.13 or greater cannot be used; the latest compatible version is 3.12.